### PR TITLE
Allow the Add method to handle new lines between numbers (instead of …

### DIFF
--- a/StringCalculaterModule.fs
+++ b/StringCalculaterModule.fs
@@ -7,7 +7,7 @@ type StringCalculator()=
      member x.add expression =
       match expression with 
       |"" -> 0
-      |_ when expression.Contains ',' ->
-         [for n in expression.Split[|','|]-> Int32.Parse n] |> List.sum  //Allow the Add method to handle an unknown amount of numbers
-      |_-> Int32.Parse expression
-
+      |_  ->
+           [for n in expression.Split[|','; '\n'|]-> Int32.Parse n] |> List.sum
+(*      |_-> Int32.Parse expression
+*)

--- a/UnitTest1.fs
+++ b/UnitTest1.fs
@@ -29,3 +29,11 @@ type stringCalculatr()=
     member x.Add_UnknownAmountOfNumber_ReturnTheirSum expression=
          let calc= StringCalculator()
          calc.add expression
+
+    
+    
+    [<TestCase("1\n2,4,5",ExpectedResult = 12)>]
+    [<TestCase("1\n2",ExpectedResult = 3)>]
+    member x.Add_NewLineBetweenTheNumbers_ReturnTheirSumOfthenumbers expression=
+         let calc= StringCalculator()
+         calc.add expression


### PR DESCRIPTION
Allow the Add method to handle new lines between numbers (instead of commas)
First I remove when expression.Contains ',' cause if we try to enter this case 
"1\n2"  the unit test generate exception cause there no comma so i want to make this possible for all cases and i remove the chicking on the 1 number cause it will never be matched so will always enter to the second rule 